### PR TITLE
Port mapping for Hortonworks  shc-core

### DIFF
--- a/docker-compose-distributed-local.yml
+++ b/docker-compose-distributed-local.yml
@@ -75,6 +75,7 @@ services:
     environment:
       SERVICE_PRECONDITION: "namenode:50070 datanode:50075 zoo:2181"
     ports:
+      - 16000:16000
       - 16010:16010
 
   hbase-region:
@@ -87,6 +88,7 @@ services:
       HBASE_CONF_hbase_regionserver_hostname: hbase-region
       SERVICE_PRECONDITION: "namenode:50070 datanode:50075 zoo:2181 hbase-master:16010"
     ports:
+      - 16020:16020
       - 16030:16030
 
 volumes:


### PR DESCRIPTION
I ought to add ports 16000( hbase-master) and 16020(hbase-regionserver) for compatibility with Hortonwork shc-core Connector(hortonworks-spark/shc)  in the case for Spark is running  outside the Docker (i/e/ in embedded mode from ITELIJI Idea , etc. )